### PR TITLE
wrap Float/parseFloat to handle empty string and nil: return 0.0

### DIFF
--- a/src/town/lilac/humble/app/gui_2.clj
+++ b/src/town/lilac/humble/app/gui_2.clj
@@ -41,7 +41,22 @@
   ;; => 41N
   (f->c 41)
   ;; => 5N
-  )
+  ,)
+
+(defn safe-parse-float
+  " behavior when text field is empty is undefined -- let's return 0.0 "
+  [s]
+  (if (or (nil? s)
+          (= s ""))
+    0.0
+    (Float/parseFloat s)))
+
+(comment
+  (safe-parse-float nil)   ;; => 0.0
+  (safe-parse-float "")    ;; => 0.0
+  (safe-parse-float "4.0") ;; => 4.0
+  0)
+
 
 (defn start!
   []
@@ -53,13 +68,13 @@
                      (swap!
                       *f-input
                       assoc :text
-                      (str (c->f (Float/parseFloat text)))))
+                      (str (c->f (safe-parse-float text)))))
         on-fahrenheit (fn on-fahrenheit-change
                         [{:keys [text]}]
                         (swap!
                          *c-input
                          assoc :text
-                         (str (f->c (Float/parseFloat text)))))]
+                         (str (f->c (safe-parse-float text)))))]
     (reset! state/*app (temp-converter
                         *c-input *f-input
                         on-celsius

--- a/src/town/lilac/humble/app/gui_2.clj
+++ b/src/town/lilac/humble/app/gui_2.clj
@@ -57,7 +57,7 @@
   (wrapped-parse-float nil)   ;; => 0.0
   (wrapped-parse-float "")    ;; => 0.0
   (wrapped-parse-float "4.0") ;; => 4.0
-  (wrapped-parse-float "abc") ;; => 4.0
+  (wrapped-parse-float "abc") ;; => 0.0
   0)
 
 

--- a/src/town/lilac/humble/app/gui_2.clj
+++ b/src/town/lilac/humble/app/gui_2.clj
@@ -43,18 +43,21 @@
   ;; => 5N
   ,)
 
-(defn safe-parse-float
-  " behavior when text field is empty is undefined -- let's return 0.0 "
+(defn- wrapped-parse-float
+  " behavior when text field is empty, undefined, not a number, etc. -- let's return 0.0 "
   [s]
-  (if (or (nil? s)
-          (= s ""))
-    0.0
-    (Float/parseFloat s)))
+  (try
+    (Float/parseFloat s)
+    (catch Exception e
+      (println (format "wrapped-parse-float: %s: exception: %s"
+                 s (.getMessage e)))
+      0.0)))
 
 (comment
-  (safe-parse-float nil)   ;; => 0.0
-  (safe-parse-float "")    ;; => 0.0
-  (safe-parse-float "4.0") ;; => 4.0
+  (wrapped-parse-float nil)   ;; => 0.0
+  (wrapped-parse-float "")    ;; => 0.0
+  (wrapped-parse-float "4.0") ;; => 4.0
+  (wrapped-parse-float "abc") ;; => 4.0
   0)
 
 
@@ -68,13 +71,13 @@
                      (swap!
                       *f-input
                       assoc :text
-                      (str (c->f (safe-parse-float text)))))
+                      (str (c->f (wrapped-parse-float text)))))
         on-fahrenheit (fn on-fahrenheit-change
                         [{:keys [text]}]
                         (swap!
                          *c-input
                          assoc :text
-                         (str (f->c (safe-parse-float text)))))]
+                         (str (f->c (wrapped-parse-float text)))))]
     (reset! state/*app (temp-converter
                         *c-input *f-input
                         on-celsius


### PR DESCRIPTION
wrapping Float/parseFloat to avoid getting stack traces in REPL console or terminal.  Fixiing as mentioned in https://clojurians.slack.com/archives/C06MAR553/p1672165502775089?thread_ts=1671647107.525429&cid=C06MAR553.

Thanks for these fantastic examples, @lilactown!